### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/server/static/script.js
+++ b/server/static/script.js
@@ -26,7 +26,7 @@ async function sendMessage() {
 
     // Show user message
     const userMsg = document.createElement("p");
-    userMsg.innerHTML = `<strong>You:</strong> ${message}`;
+    userMsg.textContent = `You: ${message}`;
     chatBox.appendChild(userMsg);
     chatBox.scrollTop = chatBox.scrollHeight;
     userInput.value = "";
@@ -34,7 +34,7 @@ async function sendMessage() {
     // Show "Assistant is typing..."
     const typingMsg = document.createElement("p");
     typingMsg.id = "typing-msg";
-    typingMsg.innerHTML = "<em>Assistant is typing...</em>";
+    typingMsg.textContent = "Assistant is typing...";
     chatBox.appendChild(typingMsg);
     chatBox.scrollTop = chatBox.scrollHeight;
 
@@ -65,7 +65,7 @@ async function sendMessage() {
         spinner.classList.add("hidden");
 
         const errorMsg = document.createElement("p");
-        errorMsg.innerHTML = "<strong>Assistant:</strong> Error occurred.";
+        errorMsg.textContent = "Assistant: Error occurred.";
         chatBox.appendChild(errorMsg);
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/shadow-kage/MCP-Demo/security/code-scanning/3](https://github.com/shadow-kage/MCP-Demo/security/code-scanning/3)

To fix the issue, the user input (`message`) should be properly escaped before being inserted into the DOM as HTML. This can be achieved by using `textContent` instead of `innerHTML` for the user message, which ensures that the input is treated as plain text rather than HTML. Alternatively, a library like `DOMPurify` can be used to sanitize the input if HTML formatting is required.

The best fix for this specific case is to replace `innerHTML` with `textContent` for the user message on line 29. This ensures that any special characters in the user input are safely escaped, preventing XSS vulnerabilities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
